### PR TITLE
Update Permissions.md

### DIFF
--- a/Permissions.md
+++ b/Permissions.md
@@ -12,7 +12,7 @@ Permission nodes used by the core TNE Jar(tne.jar).
 | tne.bypass.world | Used to bypass any world changing costs that may be configured. |
 | tne.override.mobdrop | Used to override the MobDrop configuration if it's enabled, which will allow this player to have mobs drop items that are classified as a currency on death. |
 | tne.menu.display | Provides users to the TNE Action Menu Display Icon, which lets them check player balances. |
-| tne.menu.give | Provides users to the TNE Action Menu Give Icon, which lets them give players money from thin error. |
+| tne.menu.give | Provides users to the TNE Action Menu Give Icon, which lets them give players money from thin air. |
 | tne.menu.pay | Provides users to the TNE Action Menu Pay Icon, which lets them pay players money from their own balance. |
 | tne.menu.set | Provides users to the TNE Action Menu Set Icon, which lets them set player balances. |
 | tne.menu.take | Provides users to the TNE Action Menu Take Icon, which lets them take money from player balances, and make it vanish into thin air. |


### PR DESCRIPTION
Fixes a minor documentation error where 'Thin error' was used in place of 'thin air'.